### PR TITLE
chore(gitignore): add .idea to ignore IntelliJ files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 # vscode local history
 .history
 
+# IDE(webstorm)
+.idea
+
 # testing
 /coverage
 


### PR DESCRIPTION
Added .idea directory to .gitignore to prevent webstorm configuration files (e.g., workspace settings, run configurations) from being committed. This ensures a cleaner repository and avoids conflicts between developers using different IDE settings.